### PR TITLE
fix: validate Python ABI compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -926,6 +926,10 @@ public:
 
 ### Python Bindings
 
+Python wheels support CPython 3.8 through 3.13. Each wheel ships a native
+`_sagevdb` extension for the matching Python ABI; using a mismatched extension
+will fail fast with diagnostic details.
+
 Python bindings are provided in `../python/` using pybind11:
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "isage-vdb"
-version = "0.2.0.11"
+version = "0.2.0.12"
 description = "High-Performance Vector Database with Pluggable ANNS Architecture"
 readme = "README.md"
 license = { text = "MIT" }
@@ -30,8 +30,9 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.8,<3.14"
 dependencies = [
     "numpy>=1.19.0",
     # FAISS is required because libsage_vdb.so is compiled with FAISS support
@@ -79,13 +80,11 @@ build-dir = "build/{wheel_tag}"
 # Install directory - the Python module will be installed here
 wheel.install-dir = "sagevdb"
 wheel.packages = ["sagevdb"]
-# Platform tags
-wheel.py-api = "cp311"
 # Set manylinux tag
 wheel.expand-macos-universal-tags = false
 
 [tool.cibuildwheel]
-build = ["cp38-*", "cp39-*", "cp310-*", "cp311-*", "cp312-*"]
+build = ["cp38-*", "cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*"]
 skip = ["*-musllinux*", "*-win32", "*-manylinux_i686"]
 
 [tool.cibuildwheel.linux]

--- a/sagevdb/__init__.py
+++ b/sagevdb/__init__.py
@@ -17,9 +17,13 @@ except PackageNotFoundError:
 __author__ = "IntelliStream Team"
 __email__ = "shuhao_zhang@hust.edu.cn"
 
-# Help locate libsage_vdb.so for development mode
+import glob
 import os
+import platform
 import sys
+import sysconfig
+
+# Help locate libsage_vdb.so for development mode
 
 _pkg_dir = os.path.dirname(os.path.abspath(__file__))
 if os.path.exists(os.path.join(_pkg_dir, "libsage_vdb.so")):
@@ -169,16 +173,25 @@ try:
         raise ValueError("Invalid arguments for create_database")
 
 except ImportError as e:
-    import warnings
-
-    warnings.warn(
-        f"Failed to import SageVDB native extension: {e}\n"
-        "The package may not be properly installed. "
-        "Try reinstalling with: pip install --force-reinstall SageVDB",
-        ImportWarning,
-    )
-    # Provide empty stubs to prevent total failure
-    __all__ = []
+    _expected_ext = sysconfig.get_config_var("EXT_SUFFIX") or "<unknown>"
+    _available_exts = sorted(os.path.basename(path) for path in glob.glob(os.path.join(_pkg_dir, "_sagevdb*.so")))
+    _details = [
+        f"original error: {e}",
+        f"python: {sys.executable}",
+        f"python version: {platform.python_version()}",
+        f"expected extension suffix: {_expected_ext}",
+        f"package directory: {_pkg_dir}",
+        "available native extensions: " + (", ".join(_available_exts) if _available_exts else "<none>"),
+    ]
+    raise ImportError(
+        "Failed to import sageVDB native extension. The installed isage-vdb "
+        "package does not contain a native module compatible with this Python "
+        "ABI, or one of its shared-library dependencies is missing.\n"
+        + "\n".join(f"  - {line}" for line in _details)
+        + "\nReinstall or rebuild isage-vdb with the same Python interpreter. "
+        "For development checkouts, run scripts/link_shared_libs.sh with "
+        "PYTHON_BIN set to the target interpreter."
+    ) from e
 
 # ---------------------------------------------------------------------------
 # Optional legacy bridge: current SAGE main no longer exposes ``sage.libs.vdb``.

--- a/scripts/link_shared_libs.sh
+++ b/scripts/link_shared_libs.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# link_shared_libs.sh — Symlink compiled C-extension .so files from the PyPI
+# link_shared_libs.sh - Symlink compiled C-extension .so files from the PyPI
 # install (isage-vdb) into the source checkout so that sageVDB can be placed
 # on PYTHONPATH for development without triggering a silent ImportError.
 #
@@ -7,10 +7,8 @@
 # ----------
 # The sagevdb package ships a compiled C extension (_sagevdb.cpython-*.so) and
 # a native shared library (libsage_vdb.so).  A bare git checkout does NOT
-# contain these build artefacts, so when the source directory is on PYTHONPATH,
-# sagevdb/__init__.py catches the ImportError from the missing .so, sets
-# __all__ = [], and exports like DatabaseConfig / DistanceMetric become
-# unavailable — a very confusing failure mode.
+# contain these build artifacts, so when the source directory is on PYTHONPATH,
+# native API exports like DatabaseConfig / DistanceMetric are unavailable.
 #
 # This script creates symlinks from the installed PyPI package into the source
 # tree, giving developers live Python source changes while reusing the
@@ -58,14 +56,36 @@ python_bin=$(resolve_python) || {
 
 echo "Using Python: $python_bin ($($python_bin --version 2>&1))"
 
+ext_suffix=$("$python_bin" -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX') or '')")
+if [[ -z "$ext_suffix" ]]; then
+    echo "ERROR: Could not determine Python extension suffix for $python_bin." >&2
+    exit 1
+fi
+echo "Expected extension suffix: $ext_suffix"
+
 # --- Locate installed sagevdb package ----------------------------------------
-installed_pkg=$("$python_bin" -c "
-import importlib.util, os, sys
+installed_pkg=$("$python_bin" - "$repo_root" "$src_pkg" <<'PY'
+import importlib.util
+import os
+import sys
+
+repo_root = os.path.abspath(sys.argv[1])
+src_pkg = os.path.abspath(sys.argv[2])
+source_paths = {repo_root, src_pkg, ""}
+sys.path[:] = [
+    path for path in sys.path
+    if os.path.abspath(path or os.getcwd()) not in source_paths
+]
+
 spec = importlib.util.find_spec('sagevdb')
 if spec is None or spec.origin is None:
     sys.exit(1)
-print(os.path.dirname(spec.origin))
-" 2>/dev/null) || {
+pkg_dir = os.path.abspath(os.path.dirname(spec.origin))
+if pkg_dir == src_pkg or pkg_dir.startswith(repo_root + os.sep):
+    sys.exit(2)
+print(pkg_dir)
+PY
+) || {
     echo "ERROR: sagevdb is not installed in the current Python environment." >&2
     echo "  Install it first:  pip install isage-vdb" >&2
     exit 1
@@ -80,9 +100,26 @@ fi
 
 # --- Symlink .so files --------------------------------------------------------
 so_count=0
+ext_count=0
+
 for so_file in "$installed_pkg"/*.so; do
     [[ -f "$so_file" ]] || continue
     base=$(basename "$so_file")
+
+    if [[ "$base" == _sagevdb*.so && "$base" != *"$ext_suffix" ]]; then
+        echo "  [skip]    $base (does not match $ext_suffix)"
+        continue
+    fi
+
+    if [[ "$base" != "libsage_vdb.so" && "$base" != _sagevdb*.so ]]; then
+        echo "  [skip]    $base (not a sageVDB shared library)"
+        continue
+    fi
+
+    if [[ "$base" == _sagevdb*.so ]]; then
+        ((ext_count++)) || true
+    fi
+
     target="$src_pkg/$base"
     # Skip if it already points to the right place.
     if [[ -L "$target" && "$(readlink -f "$target")" == "$(readlink -f "$so_file")" ]]; then
@@ -95,8 +132,16 @@ for so_file in "$installed_pkg"/*.so; do
 done
 
 if [[ $so_count -eq 0 ]]; then
-    echo "WARNING: No .so files found in $installed_pkg" >&2
-    echo "  The isage-vdb wheel may not include compiled extensions for this platform." >&2
+    echo "WARNING: No compatible sageVDB shared libraries found in $installed_pkg" >&2
+    echo "  Expected _sagevdb*$ext_suffix for this interpreter." >&2
+    echo "  The isage-vdb wheel may not include compiled extensions for this Python ABI." >&2
+    exit 1
+fi
+
+if [[ $ext_count -eq 0 ]]; then
+    echo "ERROR: No compatible sageVDB Python extension found in $installed_pkg" >&2
+    echo "  Expected _sagevdb*$ext_suffix for this interpreter." >&2
+    echo "  libsage_vdb.so alone is not enough for 'import sagevdb' native APIs." >&2
     exit 1
 fi
 


### PR DESCRIPTION
Build wheels for CPython 3.8 through 3.13, validate the native extension ABI during development linking, and fail with actionable diagnostics when a compatible extension is unavailable.